### PR TITLE
getStringWidth(): fixed unsigned char assumption

### DIFF
--- a/src/MiniGrafx.cpp
+++ b/src/MiniGrafx.cpp
@@ -471,7 +471,7 @@ uint16_t MiniGrafx::getStringWidth(const char* text, uint16_t length) {
   uint16_t maxWidth = 0;
 
   while (length--) {
-    stringWidth += readFontData(fontData, JUMPTABLE_START + (text[length] - firstChar) * JUMPTABLE_BYTES + JUMPTABLE_WIDTH);
+    stringWidth += readFontData(fontData, JUMPTABLE_START + ((reinterpret_cast<const unsigned char*>(text)[length]) - firstChar) * JUMPTABLE_BYTES + JUMPTABLE_WIDTH);
     if (text[length] == 10) {
       maxWidth = max(maxWidth, stringWidth);
       stringWidth = 0;


### PR DESCRIPTION
The function MiniGrafx::getStringWidth() assumed that the char type is
unsigned. It just takes a text[length] and calculates with it.

In environments where a char is signed, this can result in a negative
value, resulting of a segmentation fault because offset is negative in
MiniGrafx::readFontData(), causing pgm_read_byte() to read from
unassigned memory.

This patch adds an explicit cast to unsigned char, so the signedness of
chars does not matter anymore.