### PR TITLE
Fix MiniGrafx::drawRect() for off-by-one

### DIFF
--- a/src/MiniGrafx.cpp
+++ b/src/MiniGrafx.cpp
@@ -203,8 +203,8 @@ void MiniGrafx::drawCircle(int16_t x0, int16_t y0, uint16_t radius) {
 void MiniGrafx::drawRect(int16_t x, int16_t y, int16_t width, int16_t height) {
   drawHorizontalLine(x, y, width);
   drawVerticalLine(x, y, height);
-  drawVerticalLine(x + width, y, height);
-  drawHorizontalLine(x, y + height, width);
+  drawVerticalLine(x + width - 1, y, height);
+  drawHorizontalLine(x, y + height - 1, width);
 }
 
 void MiniGrafx::fillRect(int16_t xMove, int16_t yMove, int16_t width, int16_t height) {


### PR DESCRIPTION
The rect in MiniGrafx::drawRect() had the right and bottom line
off-by-one, resulting in

1. the rect being bigger than the rect with fillRect() with the same
   coordinates, and
2. the lower right corner missing one pixel

Fixes #58.